### PR TITLE
wallet2: fix is_synced to check current height, not target (#59)

### DIFF
--- a/src/cryptonote_core/blockchain.cpp
+++ b/src/cryptonote_core/blockchain.cpp
@@ -2230,8 +2230,9 @@ bool Blockchain::get_output_distribution(uint64_t amount, uint64_t from_height, 
   if (start_height >= db_height)	
     return false;	
   distribution.resize(db_height - start_height, 0);	
-  bool r = for_all_outputs(amount, [&](uint64_t height) {	
-    CHECK_AND_ASSERT_MES(height >= real_start_height && height <= db_height, false, "Height not in expected range");	
+  bool r = for_all_outputs(amount, [&](uint64_t height) {
+	  // ToDo test merge PR 3815 https://github.com/monero-project/monero/pull/3815/files
+    // CHECK_AND_ASSERT_MES(height >= real_start_height && height <= db_height, false, "Height not in expected range");	
     if (height >= start_height)	
       distribution[height - start_height]++;	
     else	

--- a/src/wallet/wallet2.cpp
+++ b/src/wallet/wallet2.cpp
@@ -10405,7 +10405,7 @@ uint64_t wallet2::get_blockchain_height_by_date(uint16_t year, uint8_t month, ui
 bool wallet2::is_synced() const
 {
   uint64_t height;
-  boost::optional<std::string> result = m_node_rpc_proxy.get_target_height(height);
+  boost::optional<std::string> result = m_node_rpc_proxy.get_height(height);
   if (result && *result != CORE_RPC_STATUS_OK)
     return false;
   return get_blockchain_current_height() >= height;


### PR DESCRIPTION
* wallet2: fix is_synced to check current height

The wallet syncs from the local daemon, and its target is the daemon's current height.

Reference: https://github.com/monero-project/monero/commit/5956beaa15161c3993f38c314a10633d679f0eb8

* test comment height check on get_output_distribution

ToDo test merge PR 3815 https://github.com/monero-project/monero/pull/3815/files